### PR TITLE
Fix RFC5322 compliance of response email

### DIFF
--- a/cmd/reply.go
+++ b/cmd/reply.go
@@ -77,7 +77,7 @@ func reply(r ics.PropertyParameter) {
 	e := oneEventOrDie(c)
 
 	c, subject := createResponseCalendar(e, r, from)
-	body := createResponseEmail(c, subject)
+	body := createResponseEmail(c, from, subject)
 	to := extractMailAddresses(m.From)
 	if toEmail != "" {
 		to = []string{toEmail}
@@ -136,11 +136,11 @@ func createResponseCalendar(e *ics.VEvent, reply ics.PropertyParameter, email st
 	return c, fmt.Sprintf("Subject: %s: %s\n", fmt.Sprintf("%s", reply), answer)
 }
 
-func createResponseEmail(ical *ics.Calendar, subject string) []byte {
+func createResponseEmail(ical *ics.Calendar, from string, subject string) []byte {
 	var body bytes.Buffer
+	body.WriteString(fmt.Sprintf("From: %s\n", from))
 	body.WriteString(fmt.Sprintf("Subject: %s", subject))
-	body.WriteString("MIME-Version: 1.0\n\n")
-
+	body.WriteString("MIME-Version: 1.0\n")
 	body.WriteString("Content-Type: text/calendar; charset=utf-8; method=reply\n")
 	body.WriteString("Content-Transfer-Encoding: quoted-printable\n\n")
 

--- a/cmd/reply.go
+++ b/cmd/reply.go
@@ -183,6 +183,7 @@ func sendMail(from string, to []string, body []byte) error {
 	}
 	smtpPass := strings.Trim(string(b), "\n\t ")
 	host := strings.Split(smtpAddr, ":")[0]
+	// port := strings.Split(smtpAddr, ":")[1]
 
 	err = smtp.SendMail(smtpAddr, smtp.PlainAuth("", smtpUser, smtpPass, host), from, to, body)
 	if err != nil {


### PR DESCRIPTION
The response email is missing a `FROM:` header so is not RFC 5322 compliant. This means it is likely to be rejected by lots of mail servers. 

Here is an example of it being rejected by Gmail.
```
Mar 07 11:28:13 moxie postfix/smtp[2371131]: E287A120210: to=<somemail@example.com>, relay=gmail-smtp-in.l.google.com[2607:f8b0:4023:1c01::1b]:25, delay=1.4, delays=0.82/0.02/0.25/0.33, dsn=5.7.1, status=bounced (host gmail-smtp-in.l.google.com[2607:f8b0:4023:1c01::1b] said: 550-5.7.1 [2600:3c01::f03c:91ff:fe93:30f8      11] Our system has detected that 550-5.7.1 this message is not RFC 5322 compliant: 550-5.7.1 'From' header is missing. 550-5.7.1 To reduce the amount of spam sent to Gmail, this message has been 550-5.7.1 blocked. Please visit 550-5.7.1  https://support.google.com/mail/?p=RfcMessageNonCompliant 550 5.7.1 and review RFC 5322 specifications for more information. r204-20020a632bd5000000b003804720138fsi2876735pgr.227 - gsmtp (in reply to end of DATA command))
```
This PR adds a header for the `FROM:` address and also fixes line breaks so the `Content-Type` and `Content-Transfer-Encoding` headers are in the headers and not the body of the message. 